### PR TITLE
MOB-XXXX [Provider type encoding hotfix]

### DIFF
--- a/KarhooSDK/Api/Response/Provider.swift
+++ b/KarhooSDK/Api/Response/Provider.swift
@@ -15,7 +15,7 @@ public struct Provider: KarhooCodableModel {
     public let id: String
 
     public var type: PaymentProviderType {
-        switch self.id {
+        switch self.id.lowercased() {
         case "braintree": return .braintree
         case "adyen": return .adyen
         default: return .unknown

--- a/KarhooSDKIntegrationTests/Service/Payment/PaymentProvider/PaymentProviderSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/PaymentProvider/PaymentProviderSpec.swift
@@ -34,6 +34,7 @@ final class PaymentProviderSpec: XCTestCase {
         
         call.execute(callback: { result in
             XCTAssertEqual("Adyen", result.successValue()?.provider.id)
+            XCTAssertEqual(PaymentProviderType.adyen, result.successValue()?.provider.type)
             expectation.fulfill()
         })
         


### PR DESCRIPTION
Payment provider type should be neutral to string casing. 