### PR TITLE
MOB-4495 | modified timeouts for bitrise build success rate

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,4 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
+BUNDLE_RETRY: "5"
+BUNDLE_JOBS: "20"

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ fastlane/.env
 Client/Keys.swift
 Package.resolved
 .idea
+.bitrise.secrets.yml
+
+# ruby
+/vendor

--- a/KarhooSDKIntegrationTests/Error/GeneralErrorSpec.swift
+++ b/KarhooSDKIntegrationTests/Error/GeneralErrorSpec.swift
@@ -39,7 +39,7 @@ final class GeneralErrorSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        self.waitForExpectations(timeout: 0.5, handler: .none)
+        self.waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -57,6 +57,6 @@ final class GeneralErrorSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        self.waitForExpectations(timeout: 0.5, handler: .none)
+        self.waitForExpectations(timeout: 5, handler: .none)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Address/LocationInfoMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Address/LocationInfoMethodSpec.swift
@@ -39,7 +39,7 @@ final class LocationInfoMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -58,7 +58,7 @@ final class LocationInfoMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -76,7 +76,7 @@ final class LocationInfoMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -93,7 +93,7 @@ final class LocationInfoMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -111,7 +111,7 @@ final class LocationInfoMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertLocationInfo(info: LocationInfo) {

--- a/KarhooSDKIntegrationTests/Service/Address/PlaceSearchMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Address/PlaceSearchMethodSpec.swift
@@ -39,7 +39,7 @@ final class PlaceSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -58,7 +58,7 @@ final class PlaceSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -77,7 +77,7 @@ final class PlaceSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -95,7 +95,7 @@ final class PlaceSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -113,7 +113,7 @@ final class PlaceSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     private func assertSuccess(result: Result<Places>) {

--- a/KarhooSDKIntegrationTests/Service/Address/ReverseGeocodeMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Address/ReverseGeocodeMethodSpec.swift
@@ -38,7 +38,7 @@ final class ReverseGeocodeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -59,7 +59,7 @@ final class ReverseGeocodeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -77,7 +77,7 @@ final class ReverseGeocodeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -95,7 +95,7 @@ final class ReverseGeocodeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -113,7 +113,7 @@ final class ReverseGeocodeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     private func assertLocationInfo(info: LocationInfo) {

--- a/KarhooSDKIntegrationTests/Service/Auth/AuthLoginMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Auth/AuthLoginMethodSpec.swift
@@ -38,7 +38,7 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 5)
     }
     
     /**
@@ -55,7 +55,7 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -91,7 +91,7 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -110,7 +110,7 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 5)
     }
     
     /**
@@ -129,7 +129,7 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -148,6 +148,6 @@ final class AuthLoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Auth/RevokeMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Auth/RevokeMethodSpec.swift
@@ -33,7 +33,7 @@ final class AuthRevokeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 20)
     }
 
     /**
@@ -51,6 +51,6 @@ final class AuthRevokeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Config/UIConfigMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Config/UIConfigMethodSpec.swift
@@ -33,7 +33,7 @@ final class UIConfigMethod: XCTestCase {
                                                            password: "mock")).execute(callback: { _ in
                                                             expectation.fulfill()
                                                            })
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -53,7 +53,7 @@ final class UIConfigMethod: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -73,6 +73,6 @@ final class UIConfigMethod: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/DriverTracking/DriverTrackingMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/DriverTracking/DriverTrackingMethodSpec.swift
@@ -38,7 +38,7 @@ final class DriverTrackingMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -58,7 +58,7 @@ final class DriverTrackingMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -83,8 +83,8 @@ final class DriverTrackingMethodSpec: XCTestCase {
                 expectation.fulfill()
             }
         }
-        pollCall.observable(pollTime: 0.1).subscribe(observer: observer)
-        waitForExpectations(timeout: 1)
+        pollCall.observable(pollTime: 1).subscribe(observer: observer)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -102,7 +102,7 @@ final class DriverTrackingMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertSuccess(result: Result<DriverTrackingInfo>) {

--- a/KarhooSDKIntegrationTests/Service/FareMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/FareMethodSpec.swift
@@ -42,7 +42,7 @@ final class FareMethodSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     private func assertSuccess(result: Result<Fare>) {
@@ -76,7 +76,7 @@ final class FareMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -94,7 +94,7 @@ final class FareMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -112,7 +112,7 @@ final class FareMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -130,6 +130,6 @@ final class FareMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Loyalty/LoyaltyBalanceMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Loyalty/LoyaltyBalanceMethodSpec.swift
@@ -38,7 +38,7 @@ final class LoyaltyBalanceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -57,7 +57,7 @@ final class LoyaltyBalanceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -74,7 +74,7 @@ final class LoyaltyBalanceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -91,7 +91,7 @@ final class LoyaltyBalanceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -109,6 +109,6 @@ final class LoyaltyBalanceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Loyalty/LoyaltyConversionMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Loyalty/LoyaltyConversionMethodSpec.swift
@@ -39,7 +39,7 @@ final class LoyaltyConversionMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
 
@@ -57,7 +57,7 @@ final class LoyaltyConversionMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -74,7 +74,7 @@ final class LoyaltyConversionMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -92,7 +92,7 @@ final class LoyaltyConversionMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }
 

--- a/KarhooSDKIntegrationTests/Service/Payment/AddPaymentDetails/AddPaymentDetailsMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/AddPaymentDetails/AddPaymentDetailsMethodSpec.swift
@@ -44,7 +44,7 @@ final class AddPaymentDetailsMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -65,7 +65,7 @@ final class AddPaymentDetailsMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: 20)
     }
 
     /**
@@ -83,6 +83,6 @@ final class AddPaymentDetailsMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPaymentMethodsSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPaymentMethodsSpec.swift
@@ -37,7 +37,7 @@ final class AdyenPaymentMethodsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: 100)
     }
     
     /**
@@ -59,7 +59,7 @@ final class AdyenPaymentMethodsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -78,7 +78,7 @@ final class AdyenPaymentMethodsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
 }

--- a/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPaymentsSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPaymentsSpec.swift
@@ -41,7 +41,7 @@ final class AdyenPaymentsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: 100)
     }
 
     /**
@@ -61,7 +61,7 @@ final class AdyenPaymentsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -80,6 +80,6 @@ final class AdyenPaymentsSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPublicKeySpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/Adyen/AdyenPublicKeySpec.swift
@@ -57,7 +57,7 @@ final class AdyenPublicKeySpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -76,7 +76,7 @@ final class AdyenPublicKeySpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }
 

--- a/KarhooSDKIntegrationTests/Service/Payment/GetNonceMethod/GetNonceMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/GetNonceMethod/GetNonceMethodSpec.swift
@@ -41,7 +41,7 @@ final class GetNonceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -62,7 +62,7 @@ final class GetNonceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -80,6 +80,6 @@ final class GetNonceMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Payment/PaymentProvider/PaymentProviderSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Payment/PaymentProvider/PaymentProviderSpec.swift
@@ -58,7 +58,7 @@ final class PaymentProviderSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -77,7 +77,7 @@ final class PaymentProviderSpec: XCTestCase {
             expectation.fulfill()
         })
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
 }

--- a/KarhooSDKIntegrationTests/Service/Quote/QuoteCoverageMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Quote/QuoteCoverageMethodSpec.swift
@@ -40,7 +40,7 @@ final class QuoteCoverageMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -57,7 +57,7 @@ final class QuoteCoverageMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -75,7 +75,7 @@ final class QuoteCoverageMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }
 

--- a/KarhooSDKIntegrationTests/Service/Quote/QuoteSearchMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Quote/QuoteSearchMethodSpec.swift
@@ -50,7 +50,7 @@ final class QuoteSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -68,7 +68,7 @@ final class QuoteSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -86,7 +86,7 @@ final class QuoteSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -104,7 +104,7 @@ final class QuoteSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -122,7 +122,7 @@ final class QuoteSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -151,10 +151,10 @@ final class QuoteSearchMethodSpec: XCTestCase {
             }
         }
 
-        let quotesObservable = pollCall.observable(pollTime: 0.1)
+        let quotesObservable = pollCall.observable(pollTime: 1)
         quotesObservable.subscribe(observer: quoteSearchObserver)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertSuccess(quote: Quote?) {

--- a/KarhooSDKIntegrationTests/Service/Quote/VerifyQuoteMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Quote/VerifyQuoteMethodSpec.swift
@@ -39,7 +39,7 @@ final class VerifyQuoteMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -56,7 +56,7 @@ final class VerifyQuoteMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -74,7 +74,7 @@ final class VerifyQuoteMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }
 

--- a/KarhooSDKIntegrationTests/Service/Trip/BookTripMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/BookTripMethodSpec.swift
@@ -54,7 +54,7 @@ final class BookTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -74,7 +74,7 @@ final class BookTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -92,7 +92,7 @@ final class BookTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -110,7 +110,7 @@ final class BookTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -128,7 +128,7 @@ final class BookTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertSuccess(result: Result<TripInfo>) {

--- a/KarhooSDKIntegrationTests/Service/Trip/CancelTripMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/CancelTripMethodSpec.swift
@@ -40,7 +40,7 @@ final class CancelTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -57,7 +57,7 @@ final class CancelTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -74,7 +74,7 @@ final class CancelTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -92,6 +92,6 @@ final class CancelTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Trip/CancellationFeeMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/CancellationFeeMethodSpec.swift
@@ -39,7 +39,7 @@ final class CancellationFeeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -58,7 +58,7 @@ final class CancellationFeeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -75,7 +75,7 @@ final class CancellationFeeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -92,7 +92,7 @@ final class CancellationFeeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -110,6 +110,6 @@ final class CancellationFeeMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/Trip/TrackTripMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/TrackTripMethodSpec.swift
@@ -40,7 +40,7 @@ final class TrackTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -60,7 +60,7 @@ final class TrackTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -86,8 +86,8 @@ final class TrackTripMethodSpec: XCTestCase {
                 expectation.fulfill()
             }
         }
-        pollCall.observable(pollTime: 0.3).subscribe(observer: observer)
-        waitForExpectations(timeout: 1)
+        pollCall.observable(pollTime: 0.9).subscribe(observer: observer)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -105,7 +105,7 @@ final class TrackTripMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertSuccess(result: Result<TripInfo>) {

--- a/KarhooSDKIntegrationTests/Service/Trip/TripSearchMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/TripSearchMethodSpec.swift
@@ -43,7 +43,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -62,7 +62,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -80,7 +80,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -98,7 +98,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -116,7 +116,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -134,7 +134,7 @@ final class TripSearchMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     private func assertSuccess(trip: TripInfo) {

--- a/KarhooSDKIntegrationTests/Service/Trip/TripStatusMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/Trip/TripStatusMethodSpec.swift
@@ -36,7 +36,7 @@ final class TripStatusMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -54,7 +54,7 @@ final class TripStatusMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -72,7 +72,7 @@ final class TripStatusMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -90,7 +90,7 @@ final class TripStatusMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -108,7 +108,7 @@ final class TripStatusMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -133,7 +133,7 @@ final class TripStatusMethodSpec: XCTestCase {
                 expectation.fulfill()
             }
         }
-        pollCall.observable(pollTime: 0.3).subscribe(observer: observer)
-        waitForExpectations(timeout: 1)
+        pollCall.observable(pollTime: 0.9).subscribe(observer: observer)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/User/LoginMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/User/LoginMethodSpec.swift
@@ -50,7 +50,7 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -67,7 +67,7 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -86,7 +86,7 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -106,7 +106,7 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -125,7 +125,7 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 5)
     }
 
     /**
@@ -150,7 +150,7 @@ final class LoginMethodSpec: XCTestCase {
             })
         })
 
-        wait(for: [initialLoginExpectation, secondLoginExpectation], timeout: 1)
+        wait(for: [initialLoginExpectation, secondLoginExpectation], timeout: 10)
     }
 
     /**
@@ -168,6 +168,6 @@ final class LoginMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/User/PasswordResetMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/User/PasswordResetMethodSpec.swift
@@ -37,7 +37,7 @@ final class PasswordResetMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -54,7 +54,7 @@ final class PasswordResetMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -71,7 +71,7 @@ final class PasswordResetMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 
     /**
@@ -89,6 +89,6 @@ final class PasswordResetMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKIntegrationTests/Service/User/RegisterMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/User/RegisterMethodSpec.swift
@@ -40,7 +40,7 @@ final class RegisterMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -61,7 +61,7 @@ final class RegisterMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -80,7 +80,7 @@ final class RegisterMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -98,7 +98,7 @@ final class RegisterMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     /**
@@ -116,7 +116,7 @@ final class RegisterMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 0.5, handler: .none)
+        waitForExpectations(timeout: 5, handler: .none)
     }
 
     private func assertUserInfo(info: UserInfo) {

--- a/KarhooSDKIntegrationTests/Service/User/UserDetailsUpdateMethodSpec.swift
+++ b/KarhooSDKIntegrationTests/Service/User/UserDetailsUpdateMethodSpec.swift
@@ -53,7 +53,7 @@ final class UserDetailsUpdateMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -70,7 +70,7 @@ final class UserDetailsUpdateMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -87,7 +87,7 @@ final class UserDetailsUpdateMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     /**
@@ -105,6 +105,6 @@ final class UserDetailsUpdateMethodSpec: XCTestCase {
             expectation.fulfill()
         })
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }

--- a/KarhooSDKTests/TestCases/Api/Observable/KarhooObservableSpec.swift
+++ b/KarhooSDKTests/TestCases/Api/Observable/KarhooObservableSpec.swift
@@ -21,7 +21,7 @@ final class KarhooObservableSpec: XCTestCase {
         super.setUp()
 
         testObject = Observable<MockKarhooCodableModel>(pollExecutor: mockPollExecutor,
-                                                              pollTime: 5,
+                                                              pollTime: 1.5,
                                                               broadcaster: mockObserverBroadcaster)
     }
 

--- a/KarhooSDKTests/TestCases/Api/Util/Broadcaster/BroadcasterSpec.swift
+++ b/KarhooSDKTests/TestCases/Api/Util/Broadcaster/BroadcasterSpec.swift
@@ -124,7 +124,7 @@ class BroadcasterSpec: XCTestCase {
             XCTAssert(listenerToInvoke !== listener2)
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
 
     }
 }

--- a/KarhooSDKTests/TestCases/Api/Util/WeakReferenceWrapperSpec.swift
+++ b/KarhooSDKTests/TestCases/Api/Util/WeakReferenceWrapperSpec.swift
@@ -47,7 +47,7 @@ class WeakReferenceWrapperSpec: XCTestCase {
         let storedReference = weakReferenceWrapper.getReference()
         XCTAssertNil(storedReference)
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 }
 

--- a/KarhooSDKTests/TestCases/Networking/ReachabilityWrapperSpec.swift
+++ b/KarhooSDKTests/TestCases/Networking/ReachabilityWrapperSpec.swift
@@ -195,7 +195,7 @@ class ReachabilityWrapperSpec: XCTestCase {
         DispatchQueue.main.async {
             exp.fulfill()
         }
-        wait(for: [exp], timeout: 1)
+        wait(for: [exp], timeout: 10)
     }
 }
 

--- a/KarhooSDKTests/TestCases/Networking/TokenRefresh/KarhooRefreshTokenInteractorSpec.swift
+++ b/KarhooSDKTests/TestCases/Networking/TokenRefresh/KarhooRefreshTokenInteractorSpec.swift
@@ -66,7 +66,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
 
         testObject.refreshToken(completion: { _ in})
 
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     /**
@@ -137,7 +137,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         }
         
         XCTAssertFalse(mockRequestSender.requestCalled)
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     /**
@@ -181,7 +181,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         testObject.refreshToken { _ in
         }
         
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     /**
@@ -212,7 +212,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         XCTAssertTrue(mockRequestSender.requestCalled)
         XCTAssertEqual(mockUserDataStore.storedCredentials?.accessToken, accessTokenAfterRefresh)
         
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     /**
@@ -246,7 +246,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         mockRequestSender.fail(error: expectedError)
 
         XCTAssertTrue(mockRequestSender.requestCalled)
-        wait(for: [externalAuthRequestCalledExpectation], timeout: 1)
+        wait(for: [externalAuthRequestCalledExpectation], timeout: 10)
     }
 
     /**
@@ -289,7 +289,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         mockRequestSender.success(response: requestPayload.build())
         XCTAssertTrue(mockRequestSender.requestCalled)
         XCTAssert(mockUserDataStore.setCurrentUserCalled == false)
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     /**
@@ -315,7 +315,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         let requestPayload = AuthTokenMock().set(accessToken: accessTokenAfterRefresh).set(expiresIn: 10000)
         mockRequestSender.success(response: requestPayload.build())
 
-        wait(for: [request1CompletionCalledExpectation, request2CompletionCalledExpectation], timeout: 1)
+        wait(for: [request1CompletionCalledExpectation, request2CompletionCalledExpectation], timeout: 10)
     }
 
     /**
@@ -352,7 +352,7 @@ final class KarhooRefreshTokenInteractorSpec: XCTestCase {
         }
 
         mockRequestSender.success(response: requestPayload.build())
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     private func dateInTheFarFuture() -> Date {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,7 +15,6 @@ workflows:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@7.0: {}
-    - xcodebuild@0: {}
     - script@1:
         inputs:
         - content: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,94 @@
+---
+format_version: '11'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: ios
+app:
+  envs:
+  - FASTLANE_XCODE_LIST_TIMEOUT: '120'
+  - FASTLANE_LANE: unit_tests_integration_tests
+  - ADYEN_STG_AUTHHOST: https://sso.stg.karhoo.net
+  - ADYEN_STG_GUESTHOST: https://public-api.stg.karhoo.net
+  - ADYEN_STG_HOST: https://rest.stg.karhoo.net
+workflows:
+  sandbox:
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@7.0: {}
+    - xcodebuild@0: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+            set -o pipefail
+            # debug log
+            set -x
+
+            # Script
+            echo "import KarhooSDK" > Client/Keys.swift
+                        echo "struct Keys {" >> Client/Keys.swift
+                        echo "static let identifier = \"\"" >> Client/Keys.swift
+                        echo "static let referer = \"\"" >> Client/Keys.swift
+                        echo "static let organisationId = \"\"}" >> Client/Keys.swift
+                        echo "struct AdyenSDKConfig: KarhooSDKConfiguration {" >> Client/Keys.swift
+                        echo "func environment() -> KarhooEnvironment {" >> Client/Keys.swift
+                        echo "return .custom(environment: .init(host: \"$ADYEN_STG_HOST\", authHost: \"$ADYEN_STG_AUTHHOST\", guestHost: \"$ADYEN_STG_GUESTHOST\")) }" >> Client/Keys.swift
+                        echo "func authenticationMethod() -> AuthenticationMethod {" >> Client/Keys.swift
+                        echo "return .karhooUser }" >> Client/Keys.swift
+                        echo "func requireSDKAuthentication(callback: @escaping () -> Void) {" >> Client/Keys.swift
+                        echo "callback() }" >> Client/Keys.swift
+                        echo "}" >> Client/Keys.swift
+        title: Create Keys.swift
+    - bundler@0:
+        inputs:
+        - bundle_install_jobs: '1'
+    - fastlane@3:
+        inputs:
+        - verbose_log: 'yes'
+        - lane: unit_tests_integration_tests
+        title: fastlane - unit_tests_integration_tests
+        is_always_run: true
+    - fastlane@3:
+        title: fastlane - Xcov report
+        inputs:
+        - lane: ios XcovReport
+        is_always_run: true
+    - certificate-and-profile-installer@1: {}
+    - deploy-to-bitrise-io@2: {}
+    - script@1:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -e
+            set -x
+
+            if [ "$BITRISE_GIT_TAG" != "" ] ; then
+                envman add --key FROM_MESSAGE --value 'with tag *$BITRISE_GIT_TAG*'
+            elif [ "$BITRISE_GIT_COMMIT" != "" ] ; then
+                envman add --key FROM_MESSAGE --value 'from commit *$BITRISE_GIT_COMMIT*'
+            else
+                envman add --key FROM_MESSAGE --value 'from branch *$BITRISE_GIT_BRANCH*'
+            fi
+
+            if [ "$EXISTING_URL_TAG" != "" ] ; then
+                envman add --key SUCCESS_RESPONSE --value "Skipped *$BITRISE_APP_TITLE* release build *#$BITRISE_BUILD_NUMBER* $FROM_MESSAGE - Already available at $BITRISE_PUBLIC_INSTALL_PAGE_URL"
+            else
+                envman add --key SUCCESS_RESPONSE --value "Success! *$BITRISE_APP_TITLE* release build *#$BITRISE_BUILD_NUMBER* $FROM_MESSAGE$CUSTOM_URL_MESSAGE is available at $BITRISE_PUBLIC_INSTALL_PAGE_URL"
+                envman add --key ERROR_RESPONSE --value "Failed to compile *$BITRISE_APP_TITLE* release build $FROM_MESSAGE$CUSTOM_URL_MESSAGE - $ERROR_MESSAGE $BITRISE_BUILD_URL"
+            fi
+        title: Create Slack response
+    - slack@3:
+        inputs:
+        - emoji: ":rocket:"
+        - title: 'Commit message: $GIT_CLONE_COMMIT_MESSAGE_SUBJECT'
+        - webhook_url: "$SLACK_WEBHOOK_URL"
+meta:
+  bitrise.io:
+    stack: osx-xcode-14.0.x-ventura
+trigger_map:
+- pull_request_source_branch: "*"
+  workflow: sandbox
+  pull_request_target_branch: master

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ FASTLANE_HIDE_CHANGELOG = true
 FASTLANE_SKIP_UPDATE_CHECK = true
 fastlane_require 'dotenv'
 
+
 default_platform(:ios)
 
 
@@ -10,7 +11,6 @@ platform :ios do
     ENV["SLACK_URL"] = ENV["SLACK_WEBHOOK_URL"]
     setup_circle_ci
 end
-
  desc "Danger PR Validation"
   lane :DangerPRValidation do
     danger(
@@ -25,7 +25,6 @@ end
       danger_id: "POST_CI",
      )
  end
-
   desc "Description of what the lane does"
   lane :unit_tests_integration_tests do
 	scan(
@@ -39,7 +38,6 @@ end
             output_files: "NetworkSDKTests.xml"
     )
   end
-
   desc "Xcov Report"
   lane :XcovReport do
     xcov(
@@ -50,27 +48,4 @@ end
       slack_message: "KarhooSDK test coverage report:"
     )
   end
-
-################
-# Success/Error:
-################
-
-after_all do |lane|
-  # This block is called, only if the executed lane was successful
-    slack(
-      channel: "#mobile_circleci_results",
-      message: nil,
-      default_payloads: [:test_result, :git_branch]
-    )
-    clean_build_artifacts
- end
-
-error do |lane, exception|
-    slack(
-      channel: "#mobile_circleci_results",
-      message: exception.to_s,
-      success: false
-    )
-  end
-
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ end
       danger_id: "POST_CI",
      )
  end
-  desc "Description of what the lane does"
+  desc "FASTLANE - Integration test run"
   lane :unit_tests_integration_tests do
 	scan(
 	    project: "KarhooSDK.xcodeproj",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,6 @@ end
       scheme: "KarhooSDK",
       output_directory: "fastlane/test_output",
       ignore_file_path: "./*view.swift",
-      slack_message: "KarhooSDK test coverage report:"
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,15 +2,13 @@ FASTLANE_HIDE_CHANGELOG = true
 FASTLANE_SKIP_UPDATE_CHECK = true
 fastlane_require 'dotenv'
 
-
 default_platform(:ios)
-
 
 platform :ios do
   before_all do
     ENV["SLACK_URL"] = ENV["SLACK_WEBHOOK_URL"]
-    setup_circle_ci
 end
+
  desc "Danger PR Validation"
   lane :DangerPRValidation do
     danger(
@@ -25,6 +23,7 @@ end
       danger_id: "POST_CI",
      )
  end
+
   desc "FASTLANE - Integration test run"
   lane :unit_tests_integration_tests do
 	scan(
@@ -38,7 +37,8 @@ end
             output_files: "NetworkSDKTests.xml"
     )
   end
-  desc "Xcov Report"
+  
+  desc "FASTLANE - Xcov Report"
   lane :XcovReport do
     xcov(
       project: "KarhooSDK.xcodeproj",
@@ -47,4 +47,5 @@ end
       ignore_file_path: "./*view.swift",
     )
   end
+  
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,7 +30,7 @@ Danger publish test results
 ```
 fastlane ios unit_tests_integration_tests
 ```
-Description of what the lane does
+FASTLANE - Integration test run
 ### ios XcovReport
 ```
 fastlane ios XcovReport


### PR DESCRIPTION
## JIRA
[MOB-4495](https://karhoo.atlassian.net/browse/MOB-4495)

## DESCRIPTION
Testing unit test threshold changes as I feel BITRISE agents are not quick enough for these aggressive thresholds.

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix 
- [ ] New feature 
- [x] Tech Debt
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Other: *define what type of change it is*



[MOB-4495]: https://karhoo.atlassian.net/browse/MOB-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ